### PR TITLE
Fix compilation, accelerometer and gyro data format as well as scaling factors

### DIFF
--- a/include/AK8963_Magnetometer.h
+++ b/include/AK8963_Magnetometer.h
@@ -38,7 +38,7 @@ uint8_t Mmode = 0x02;                 // 2 for 8 Hz, 6 for 100 Hz continuous
                                       // magnetometer data read
 
 typedef struct AK8963_MagData_s {
-  lsm303DLHCMagData_s() : x(0), y(0), z(0) {}
+  AK8963_MagData_s() : x(0), y(0), z(0) {}
   int16_t x;
   int16_t y;
   int16_t z;

--- a/include/I2CBus.cpp
+++ b/include/I2CBus.cpp
@@ -1,7 +1,14 @@
 #include "I2CBus.h"
 #include <unistd.h>
 #include <fcntl.h>
+#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
+#include <sys/ioctl.h>
+
+__s32 i2c_smbus_read_byte_data(int file, __u8 command);
+__s32 i2c_smbus_write_byte_data(int file, __u8 command, __u8 value);
+__s32 i2c_smbus_read_i2c_block_data(int file, __u8 command, __u8 length,
+                                    __u8 *values);
 
 I2CBus::I2CBus(const char * deviceName)
 {
@@ -57,4 +64,63 @@ void I2CBus::readBlock(uint8_t command, uint8_t size, uint8_t * data)
     {
         throw posix_error("Failed to read block from I2C");
     }
+}
+
+__s32 i2c_smbus_access(int file, char read_write, __u8 command,
+		       int size, union i2c_smbus_data *data)
+{
+	struct i2c_smbus_ioctl_data args;
+	__s32 err;
+
+	args.read_write = read_write;
+	args.command = command;
+	args.size = size;
+	args.data = data;
+
+	err = ioctl(file, I2C_SMBUS, &args);
+	if (err == -1)
+		err = -errno;
+	return err;
+}
+
+__s32 i2c_smbus_read_byte_data(int file, __u8 command)
+{
+	union i2c_smbus_data data;
+	int err;
+
+	err = i2c_smbus_access(file, I2C_SMBUS_READ, command,
+			       I2C_SMBUS_BYTE_DATA, &data);
+	if (err < 0)
+		return err;
+
+	return 0x0FF & data.byte;
+}
+
+__s32 i2c_smbus_write_byte_data(int file, __u8 command, __u8 value)
+{
+	union i2c_smbus_data data;
+	data.byte = value;
+	return i2c_smbus_access(file, I2C_SMBUS_WRITE, command,
+				I2C_SMBUS_BYTE_DATA, &data);
+}
+
+__s32 i2c_smbus_read_i2c_block_data(int file, __u8 command, __u8 length,
+				    __u8 *values)
+{
+	union i2c_smbus_data data;
+	int i, err;
+
+	if (length > I2C_SMBUS_BLOCK_MAX)
+		length = I2C_SMBUS_BLOCK_MAX;
+	data.block[0] = length;
+
+	err = i2c_smbus_access(file, I2C_SMBUS_READ, command,
+			       length == 32 ? I2C_SMBUS_I2C_BLOCK_BROKEN :
+				I2C_SMBUS_I2C_BLOCK_DATA, &data);
+	if (err < 0)
+		return err;
+
+	for (i = 1; i <= data.block[0]; i++)
+		values[i-1] = data.block[i];
+	return data.block[0];
 }

--- a/include/MPU9250_Acc_Gyro.cpp
+++ b/include/MPU9250_Acc_Gyro.cpp
@@ -15,7 +15,7 @@ void MPU9250_Acc_Gyro::begin(void) {
   // be higher than 1 / 0.0059 = 170 Hz
   // DLPF_CFG = bits 2:0 = 011; this limits the sample rate to 1000 Hz for both
   // With the MPU9250, it is possible to get gyro sample rates of 32 kHz (!), 8 kHz, or 1 kHz
-   writeByte(MPU9250_ADDRESS, CONFIG, 0x03);
+  i2cObject.writeByte(CONFIG, 0x03);
 
   // Set sample rate = gyroscope output rate/(1 + SMPLRT_DIV)
   i2cObject.writeByte(SMPLRT_DIV, 0x04);  // Use a 200 Hz rate; a rate consistent with the filter update rate
@@ -45,21 +45,21 @@ void MPU9250_Acc_Gyro::begin(void) {
   // Set interrupt pin active high, push-pull, hold interrupt pin level HIGH until interrupt cleared,
   // clear on read of INT_STATUS, and enable I2C_BYPASS_EN so additional chips
   // can join the I2C bus and all can be controlled by the Arduino as master
-  writeByte(MPU9250_ADDRESS, INT_PIN_CFG, 0x22);
-  writeByte(MPU9250_ADDRESS, INT_ENABLE, 0x01);  // Enable data ready (bit 0) interrupt
+  i2cObject.writeByte(INT_PIN_CFG, 0x22);
+  i2cObject.writeByte(INT_ENABLE, 0x01);  // Enable data ready (bit 0) interrupt
 }
 
 void MPU9250_Acc_Gyro::read(void) {
   uint8_t block_Acc[6];  // x/y/z accelerometer registers data to be stored here
   uint8_t block_Gyr[6];  // x/y/z gyroscope registers data to be stored here
 
-  if(readByte(INT_STATUS) & 0x01) { // wait for magnetometer data ready bit to be set
-  readBlock(ACCEL_XOUT_H, sizeof(block_Acc), block_Acc);  // Read the six raw data and ST2 registers sequentially into data array
+  if(i2cObject.readByte(INT_STATUS) & 0x01) { // wait for magnetometer data ready bit to be set
+  i2cObject.readBlock(ACCEL_XOUT_H, sizeof(block_Acc), block_Acc);  // Read the six raw data and ST2 registers sequentially into data array
   raw.acc_x = ((int16_t)block_Acc[1] << 8) | block_Acc[0] ;  // Turn the MSB and LSB into a signed 16-bit value
   raw.acc_y = ((int16_t)block_Acc[3] << 8) | block_Acc[2] ;  // Data stored as little Endian
   raw.acc_z = ((int16_t)block_Acc[5] << 8) | block_Acc[4] ;
 
-  readBlock(GYRO_XOUT_H, sizeof(block_Gyr), block_Gyr);  // Read the six raw data and ST2 registers sequentially into data array
+  i2cObject.readBlock(GYRO_XOUT_H, sizeof(block_Gyr), block_Gyr);  // Read the six raw data and ST2 registers sequentially into data array
   raw.gyr_x = ((int16_t)block_Gyr[1] << 8) | block_Gyr[0] ;  // Turn the MSB and LSB into a signed 16-bit value
   raw.gyr_y = ((int16_t)block_Gyr[3] << 8) | block_Gyr[2] ;  // Data stored as little Endian
   raw.gyr_z = ((int16_t)block_Gyr[5] << 8) | block_Gyr[4] ;

--- a/include/MPU9250_Acc_Gyro.cpp
+++ b/include/MPU9250_Acc_Gyro.cpp
@@ -55,14 +55,14 @@ void MPU9250_Acc_Gyro::read(void) {
 
   if(i2cObject.readByte(INT_STATUS) & 0x01) { // wait for magnetometer data ready bit to be set
   i2cObject.readBlock(ACCEL_XOUT_H, sizeof(block_Acc), block_Acc);  // Read the six raw data and ST2 registers sequentially into data array
-  raw.acc_x = ((int16_t)block_Acc[1] << 8) | block_Acc[0] ;  // Turn the MSB and LSB into a signed 16-bit value
-  raw.acc_y = ((int16_t)block_Acc[3] << 8) | block_Acc[2] ;  // Data stored as little Endian
-  raw.acc_z = ((int16_t)block_Acc[5] << 8) | block_Acc[4] ;
+  raw.acc_x = ((int16_t)block_Acc[0] << 8) | block_Acc[1] ;  // Turn the MSB and LSB into a signed 16-bit value
+  raw.acc_y = ((int16_t)block_Acc[2] << 8) | block_Acc[3] ;  // Data stored as big Endian
+  raw.acc_z = ((int16_t)block_Acc[4] << 8) | block_Acc[5] ;
 
   i2cObject.readBlock(GYRO_XOUT_H, sizeof(block_Gyr), block_Gyr);  // Read the six raw data and ST2 registers sequentially into data array
-  raw.gyr_x = ((int16_t)block_Gyr[1] << 8) | block_Gyr[0] ;  // Turn the MSB and LSB into a signed 16-bit value
-  raw.gyr_y = ((int16_t)block_Gyr[3] << 8) | block_Gyr[2] ;  // Data stored as little Endian
-  raw.gyr_z = ((int16_t)block_Gyr[5] << 8) | block_Gyr[4] ;
+  raw.gyr_x = ((int16_t)block_Gyr[0] << 8) | block_Gyr[1] ;  // Turn the MSB and LSB into a signed 16-bit value
+  raw.gyr_y = ((int16_t)block_Gyr[2] << 8) | block_Gyr[3] ;  // Data stored as big Endian
+  raw.gyr_z = ((int16_t)block_Gyr[4] << 8) | block_Gyr[5] ;
   }
 
 }

--- a/include/MPU9250_Acc_Gyro.h
+++ b/include/MPU9250_Acc_Gyro.h
@@ -20,6 +20,7 @@
 
 #define INT_PIN_CFG      0x37
 #define INT_ENABLE       0x38
+#define INT_STATUS       0x3A
 
 #define PWR_MGMT_1       0x6B // Device defaults to the SLEEP mode
 #define PWR_MGMT_2       0x6C
@@ -45,7 +46,7 @@ uint8_t Ascale = AFS_2G;
 
 typedef struct MPU9250AccelData_s {
   MPU9250AccelData_s()
-  : gir_x(0), gir_y(0), gir_z(0), acc_x(0), acc_y(0), acc_z(0) {}
+  : gyr_x(0), gyr_y(0), gyr_z(0), acc_x(0), acc_y(0), acc_z(0) {}
   int16_t gyr_x;
   int16_t gyr_y;
   int16_t gyr_z;

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,11 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <maintainer email="jusgomen@gmail.com">Juan Gonzalez</maintainer>
 
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -76,9 +76,9 @@ int main(int argc, char **argv)
     imu.angular_velocity.y = acc_gyro.raw.gyr_y * GYRO_SENSITIVITY_2000DPS * SENSORS_DPS_TO_RADS;
     imu.angular_velocity.z = acc_gyro.raw.gyr_z * GYRO_SENSITIVITY_2000DPS * SENSORS_DPS_TO_RADS;
 
-    imu.linear_acceleration.x = acc_gyro.raw.acc_x * ACC_SENSITIVITY_2G;
-    imu.linear_acceleration.y = acc_gyro.raw.acc_y * ACC_SENSITIVITY_2G;
-    imu.linear_acceleration.z = acc_gyro.raw.acc_z * ACC_SENSITIVITY_2G;
+    imu.linear_acceleration.x = acc_gyro.raw.acc_x * ACC_SENSITIVITY_2G * SENSORS_GRAVITY_STANDARD;
+    imu.linear_acceleration.y = acc_gyro.raw.acc_y * ACC_SENSITIVITY_2G * SENSORS_GRAVITY_STANDARD;
+    imu.linear_acceleration.z = acc_gyro.raw.acc_z * ACC_SENSITIVITY_2G * SENSORS_GRAVITY_STANDARD;
 
     chatter_pub.publish(imu);
 

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -12,7 +12,8 @@
 
 /* Constants */
 #define PI                                (3.14159265F)
-#define GYRO_SENSITIVITY_2000DPS          (0.070F)
+#define GYRO_SENSITIVITY_2000DPS          (0.06097560975609F)
+#define ACC_SENSITIVITY_2G                (0.00006103515625F)
 #define SENSORS_GRAVITY_EARTH             (9.80665F)              /**< Earth's gravity in m/s^2 */
 #define SENSORS_GRAVITY_STANDARD          (SENSORS_GRAVITY_EARTH)
 #define SENSORS_DPS_TO_RADS               (0.017453293F)          /**< Degrees/s to rad/s multiplier */
@@ -75,9 +76,9 @@ int main(int argc, char **argv)
     imu.angular_velocity.y = acc_gyro.raw.gyr_y * GYRO_SENSITIVITY_2000DPS * SENSORS_DPS_TO_RADS;
     imu.angular_velocity.z = acc_gyro.raw.gyr_z * GYRO_SENSITIVITY_2000DPS * SENSORS_DPS_TO_RADS;
 
-    imu.linear_acceleration.x = acc_gyro.raw.acc_x * SENSORS_GRAVITY_STANDARD;
-    imu.linear_acceleration.y = acc_gyro.raw.acc_y * SENSORS_GRAVITY_STANDARD;
-    imu.linear_acceleration.z = acc_gyro.raw.acc_z * SENSORS_GRAVITY_STANDARD;
+    imu.linear_acceleration.x = acc_gyro.raw.acc_x * ACC_SENSITIVITY_2G;
+    imu.linear_acceleration.y = acc_gyro.raw.acc_y * ACC_SENSITIVITY_2G;
+    imu.linear_acceleration.z = acc_gyro.raw.acc_z * ACC_SENSITIVITY_2G;
 
     chatter_pub.publish(imu);
 

--- a/src/talker.cpp
+++ b/src/talker.cpp
@@ -1,9 +1,9 @@
 #include "ros/ros.h"
 #include "sensor_msgs/Imu.h"
 
-#include <AK8963AK8963_Magnetometer.h>
+#include <AK8963_Magnetometer.h>
 #include <MPU9250_Acc_Gyro.h>
-#include <AK8963AK8963_Magnetometer.cpp>
+#include <AK8963_Magnetometer.cpp>
 #include <MPU9250_Acc_Gyro.cpp>
 #include <I2CBus.cpp>
 #include <unistd.h>
@@ -11,7 +11,7 @@
 #include <limits.h>
 
 /* Constants */
-#define PI                                (3.14159265F);
+#define PI                                (3.14159265F)
 #define GYRO_SENSITIVITY_2000DPS          (0.070F)
 #define SENSORS_GRAVITY_EARTH             (9.80665F)              /**< Earth's gravity in m/s^2 */
 #define SENSORS_GRAVITY_STANDARD          (SENSORS_GRAVITY_EARTH)
@@ -20,6 +20,7 @@
 
 int main(int argc, char **argv)
 {
+  float pitch, yaw, roll;
   const char* i2cDevice = "/dev/i2c-1";
   MPU9250_Acc_Gyro acc_gyro(i2cDevice);
   AK8963_Magnetometer mag(i2cDevice);
@@ -51,13 +52,13 @@ int main(int argc, char **argv)
     imu.linear_acceleration_covariance = {0.0025, 0, 0, 0, 0.0025, 0, 0, 0, 0.0025};
 
     roll = (float)atan2(acc_gyro.raw.acc_y, acc_gyro.raw.acc_z);
-    imu.orientation.x = roll
+    imu.orientation.x = roll;
 
-    if (acc_gyro.raw.acc_y * sin(roll) + acc.raw.acc_gyro.raw.acc_z * cos(roll))==0{
+    if ((acc_gyro.raw.acc_y * sin(roll) + acc_gyro.raw.acc_z * cos(roll)) == 0) {
       if (acc_gyro.raw.acc_x>0){
-        pitch = PI / 2
+        pitch = PI / 2;
       } else{
-        pitch = -PI / 2
+        pitch = -PI / 2;
       }
     }else{
       pitch = (float)atan(-acc_gyro.raw.acc_x / (acc_gyro.raw.acc_y * sin(roll) + acc_gyro.raw.acc_z * cos(roll)));


### PR DESCRIPTION
I fixed the basic errors to get the node to compile on a Raspberry Pi (current Raspbian).
Also added the mandatory license tag to package.xml. I left the default "BSD" in there, as I found no license information in the code. Please check and decide on a license.
Also the accelerometer and gyroscope data was the wrong endianness.
Lastly, I changed the scaling factors to match what's in the datasheet (mostly the accelerometer was off).
Values that are now returned at least look like they could be plausible.